### PR TITLE
Api proposal : the store state's type is inferred by the creation method

### DIFF
--- a/examples/basic/build.gradle
+++ b/examples/basic/build.gradle
@@ -11,6 +11,6 @@ repositories {
 dependencies {
   compile project(':lib')
 
-  compile 'com.github.jvm-redux.jvm-redux-api:api:1.2.0'
+  compile     'com.github.jvm-redux.jvm-redux-api:api:creator-creates-store-with-reducer-type-SNAPSHOT'
   testCompile 'junit:junit:4.12'
 }

--- a/examples/basic/build.gradle
+++ b/examples/basic/build.gradle
@@ -11,6 +11,6 @@ repositories {
 dependencies {
   compile project(':lib')
 
-  compile     'com.github.jvm-redux.jvm-redux-api:api:creator-creates-store-with-reducer-type-SNAPSHOT'
+  compile 'com.github.jvm-redux.jvm-redux-api:api:2.0.0'
   testCompile 'junit:junit:4.12'
 }

--- a/examples/basic/src/main/java/com/glung/redux/BasicApplication.java
+++ b/examples/basic/src/main/java/com/glung/redux/BasicApplication.java
@@ -3,7 +3,7 @@ package com.glung.redux;
 class BasicApplication {
 
     public static void main(String[] args) {
-        final Store.Creator<Integer> creator = new Store.Creator<>();
+        final Store.Creator creator = new Store.Creator();
         final ReduxApplication application = new ReduxApplication(creator, System.out);
         application.runDemo();
     }

--- a/examples/basic/src/main/java/com/glung/redux/ReduxApplication.java
+++ b/examples/basic/src/main/java/com/glung/redux/ReduxApplication.java
@@ -8,7 +8,7 @@ class ReduxApplication {
     private final redux.api.Store<Integer> store;
     private final PrintStream stream;
 
-    ReduxApplication(redux.api.Store.Creator<Integer> storeCreator, PrintStream stream) {
+    ReduxApplication(redux.api.Store.Creator storeCreator, PrintStream stream) {
         store = storeCreator.create(new MyReducer(), 0);
         this.stream = stream;
     }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -9,7 +9,6 @@ repositories {
 }
 
 dependencies {
-  compile 'com.github.jvm-redux.jvm-redux-api:api:1.2.0'
-
-  testCompile 'com.github.jvm-redux.jvm-redux-api:specs:1.2.0'
+  compile     'com.github.jvm-redux.jvm-redux-api:api:creator-creates-store-with-reducer-type-SNAPSHOT'
+  testCompile 'com.github.jvm-redux.jvm-redux-api:specs:creator-creates-store-with-reducer-type-SNAPSHOT'
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -9,6 +9,6 @@ repositories {
 }
 
 dependencies {
-  compile     'com.github.jvm-redux.jvm-redux-api:api:creator-creates-store-with-reducer-type-SNAPSHOT'
-  testCompile 'com.github.jvm-redux.jvm-redux-api:specs:creator-creates-store-with-reducer-type-SNAPSHOT'
+  compile     'com.github.jvm-redux.jvm-redux-api:api:2.0.0'
+  testCompile 'com.github.jvm-redux.jvm-redux-api:specs:2.0.0'
 }

--- a/lib/src/main/java/com/glung/redux/Middlewares.java
+++ b/lib/src/main/java/com/glung/redux/Middlewares.java
@@ -43,15 +43,19 @@ public class Middlewares {
 
     }
 
-    public static <S> Store.Enhancer<S> applyMiddlewares(final Middleware<S>... middlewares) {
-        return new Store.Enhancer<S>() {
+    public static <T> Store.Enhancer applyMiddlewares(final Middleware<T>... middlewares) {
+        return new Store.Enhancer() {
             @Override
-            public Store.Creator<S> enhance(final Store.Creator<S> next) {
-                return new Store.Creator<S>() {
+            public Store.Creator enhance(final Store.Creator next) {
+                return new Store.Creator() {
                     @Override
-                    public Store<S> create(final Reducer<S> reducer, final S initialState) {
-                        Store<S> store = next.create(reducer, initialState);
-                        return new MiddlewareStore<>(store, createMiddlewareDispatcher(Arrays.asList(middlewares), store));
+                    public <S> Store<S> create(final Reducer<S> reducer, final S initialState) {
+                        final Store<S> store = next.create(reducer, initialState);
+                        // This is fqr from ideal but currently it is expected that the Middleware and the Reducer carry the same type.
+                        // This is checked at run time (cf down cast below)
+                        //
+                        // Revisit when needed
+                        return new MiddlewareStore<>(store, createMiddlewareDispatcher(Arrays.asList(middlewares), (Store<T>) store));
                     }
                 };
             }

--- a/lib/src/main/java/com/glung/redux/Store.java
+++ b/lib/src/main/java/com/glung/redux/Store.java
@@ -47,7 +47,7 @@ public class Store<S> implements redux.api.Store<S> {
 
     private void setReducer(Reducer<S> reducer) {
         this.reducer = reducer;
-        this.reducer.reduce(currentState, redux.api.Store.INIT);
+        this.currentState = this.reducer.reduce(currentState, redux.api.Store.INIT);
     }
 
     @Override

--- a/lib/src/main/java/com/glung/redux/Store.java
+++ b/lib/src/main/java/com/glung/redux/Store.java
@@ -14,6 +14,11 @@ public class Store<S> implements redux.api.Store<S> {
     private Reducer<S> reducer;
     private S currentState;
 
+    public static <S> redux.api.Store<S> createStore(Reducer<S> reducer, S initialState, Enhancer enhancer) {
+        final redux.api.Store.Creator creator = enhancer != null ? enhancer.enhance(new Creator()) : new Creator();
+        return creator.create(reducer, initialState);
+    }
+
     Store(Reducer<S> reducer, S initialState) {
         this.currentState = initialState;
         setReducer(reducer);

--- a/lib/src/main/java/com/glung/redux/Store.java
+++ b/lib/src/main/java/com/glung/redux/Store.java
@@ -82,11 +82,11 @@ public class Store<S> implements redux.api.Store<S> {
         isReducing.set(true);
     }
 
-    public static class Creator<S> implements redux.api.Store.Creator<S> {
+    public static class Creator implements redux.api.Store.Creator {
 
         @Override
-        public redux.api.Store<S> create(Reducer<S> reducer, S initialState) {
-            return new Store<S>(reducer, initialState);
+        public <S> redux.api.Store<S> create(Reducer<S> reducer, S initialState) {
+            return new Store<>(reducer, initialState);
         }
     }
 }

--- a/lib/src/test/java/com/glung/redux/MiddlewaresTest.java
+++ b/lib/src/test/java/com/glung/redux/MiddlewaresTest.java
@@ -27,12 +27,12 @@ import java.util.List;
 public class MiddlewaresTest {
 
     @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
-    @Mock private redux.api.Store.Creator<State> storeCreator;
+    @Mock private redux.api.Store.Creator storeCreator;
     @Mock private Store<State> storeMock;
 
     private final List<String> callOrderResult = new ArrayList<>();
 
-    private Store.Creator<State> enhancedStoreCreator() {
+    private Store.Creator enhancedStoreCreator() {
         when(storeCreator.create(any(Reducer.class), any(State.class))).thenReturn(storeMock);
 
         return applyMiddlewares(createMiddleware("ONE"),

--- a/lib/src/test/java/com/glung/redux/StoreTest.java
+++ b/lib/src/test/java/com/glung/redux/StoreTest.java
@@ -1,11 +1,13 @@
 package com.glung.redux;
 
+import org.jetbrains.annotations.NotNull;
 import redux.api.Reducer;
 
 public class StoreTest extends redux.api.StoreTest {
 
+    @NotNull
     @Override
-    public <S> redux.api.Store createStore(Reducer<S> reducer, S state) {
-        return new Store.Creator<S>().create(reducer, state);
+    public <S> redux.api.Store<S> createStore(@NotNull Reducer<S> reducer, @NotNull S state) {
+        return new Store.Creator().create(reducer, state);
     }
 }


### PR DESCRIPTION
# Scope 

Implements redux-java new API proposal

# Details 

Api proposal: the store state's type is inferred by the creation method and not the Creator object. These approaches are similar, the former is more functional-like when the latter is more OO-like. 

But the functional one makes is actually easier to implement the dev-store https://github.com/glung/jvm-redux-devtools-instrument
